### PR TITLE
refactor: Make email categories fully configurable via YAML

### DIFF
--- a/email_labeler/config.py
+++ b/email_labeler/config.py
@@ -176,21 +176,10 @@ logging.basicConfig(
 
 # Gmail labels
 PROCESSED_LABEL = "Processed"
-CATEGORY_LABELS = [
-    "Marketing",
-    "Response Needed / High Priority",
-    "Bills",
-    "Subscriptions",
-    "Newsletters",
-    "Personal",
-    "Work",
-    "Events",
-    "Travel",
-    "Receipts",
-    "Low quality",
-    "Notifications",
-    "Other",
-]
+# NOTE: CATEGORY_LABELS has been removed. Categories are now configured via
+# pipeline.transform.categories in YAML config or TransformConfig dataclass.
+# This provides better flexibility and allows users to customize categories
+# without modifying source code.
 
 # LLM Configuration
 LLM_SERVICE = os.getenv("LLM_SERVICE", "OpenAI")  # "OpenAI" or "Ollama"

--- a/email_labeler/config.py
+++ b/email_labeler/config.py
@@ -176,10 +176,6 @@ logging.basicConfig(
 
 # Gmail labels
 PROCESSED_LABEL = "Processed"
-# NOTE: CATEGORY_LABELS has been removed. Categories are now configured via
-# pipeline.transform.categories in YAML config or TransformConfig dataclass.
-# This provides better flexibility and allows users to customize categories
-# without modifying source code.
 
 # LLM Configuration
 LLM_SERVICE = os.getenv("LLM_SERVICE", "OpenAI")  # "OpenAI" or "Ollama"

--- a/email_labeler/labeler.py
+++ b/email_labeler/labeler.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import List, Optional
 
-from .config import CATEGORY_LABELS, LLM_SERVICE, OLLAMA_MODEL, OPENAI_MODEL, PROCESSED_LABEL
+from .config import LLM_SERVICE, OLLAMA_MODEL, OPENAI_MODEL, PROCESSED_LABEL
 from .database import EmailDatabase
 from .email_processor import EmailProcessor
 from .llm_service import LLMService
@@ -16,6 +16,7 @@ class EmailAutoLabeler:
 
     def __init__(
         self,
+        categories: List[str],
         database: EmailDatabase = None,
         llm_service: LLMService = None,
         email_processor: EmailProcessor = None,
@@ -26,6 +27,7 @@ class EmailAutoLabeler:
         """Initialize the email auto-labeler.
 
         Args:
+            categories: List of category labels for email classification.
             database: Optional EmailDatabase instance. If not provided, creates a new one.
             llm_service: Optional LLMService instance. If not provided, creates a new one.
             email_processor: Optional EmailProcessor instance. If not provided, creates a new one.
@@ -33,12 +35,13 @@ class EmailAutoLabeler:
             test_mode: Whether to run in test mode.
             preview_mode: Whether to run in preview mode.
         """
+        self.categories = categories
         self.test_mode = test_mode
         self.preview_mode = preview_mode
 
         # Initialize components with dependency injection
         self.database = database or EmailDatabase()
-        self.llm_service = llm_service or LLMService()
+        self.llm_service = llm_service or LLMService(categories=categories)
         self.email_processor = email_processor or EmailProcessor()
         self.metrics = metrics_tracker or (MetricsTracker() if test_mode else None)
 
@@ -53,7 +56,7 @@ class EmailAutoLabeler:
             self.label_ids_cache["processed"] = self.email_processor.get_or_create_label(
                 PROCESSED_LABEL
             )
-            for label in CATEGORY_LABELS:
+            for label in self.categories:
                 self.label_ids_cache[label] = self.email_processor.get_or_create_label(label)
         return self.label_ids_cache
 

--- a/email_labeler/pipeline/orchestrator.py
+++ b/email_labeler/pipeline/orchestrator.py
@@ -62,7 +62,9 @@ class EmailPipeline:
         if self.database is None:
             self.database = EmailDatabase()
         if self.llm_service is None:
-            self.llm_service = LLMService(lazy_init=True)
+            self.llm_service = LLMService(
+                categories=self.config.transform.categories, lazy_init=True
+            )
         if self.metrics_tracker is None:
             self.metrics_tracker = MetricsTracker()
 

--- a/email_labeler/pipeline/transform_stage.py
+++ b/email_labeler/pipeline/transform_stage.py
@@ -31,7 +31,7 @@ class TransformStage(PipelineStage):
         """
         super().__init__()
         self.config = config
-        self.llm_service = llm_service or LLMService()
+        self.llm_service = llm_service or LLMService(categories=config.categories)
         self.email_processor = email_processor or EmailProcessor()
 
     def execute(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,10 +298,14 @@ def llm_service(mock_openai_client):
 
 
 @pytest.fixture
-def real_llm_service(mock_openai_client):
+def real_llm_service(mock_openai_client, pipeline_config):
     """Create a real LLMService instance with mocked client."""
 
-    return LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+    return LLMService(
+        categories=pipeline_config.transform.categories,
+        llm_client=mock_openai_client,
+        model="gpt-3.5-turbo",
+    )
 
 
 @pytest.fixture
@@ -331,9 +335,10 @@ def mock_email_processor(mock_gmail_client):
 
 
 @pytest.fixture
-def email_auto_labeler(mock_email_processor, llm_service, mock_metrics_tracker):
+def email_auto_labeler(mock_email_processor, llm_service, mock_metrics_tracker, pipeline_config):
     """Create an EmailAutoLabeler instance with mocked dependencies."""
     labeler = EmailAutoLabeler(
+        categories=pipeline_config.transform.categories,
         email_processor=mock_email_processor,
         llm_service=llm_service,
         metrics_tracker=mock_metrics_tracker,

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -153,15 +153,21 @@ class TestFactoryFunctions:
         """Test creating LLMService with provided client."""
         mock_client = MagicMock()
         model = "gpt-4"
+        test_categories = ["Work", "Personal", "Other"]
 
-        service = create_llm_service(llm_client=mock_client, model=model)
+        service = create_llm_service(
+            categories=test_categories, llm_client=mock_client, model=model
+        )
 
         assert isinstance(service, LLMService)
         assert service.llm_client == mock_client
         assert service.model == model
+        assert service.categories == test_categories
 
     def test_create_llm_service_without_client(self):
         """Test creating LLMService without client."""
+        test_categories = ["Work", "Personal", "Other"]
+
         with patch("email_labeler.factory.create_llm_client") as mock_create_client:
             mock_client = MagicMock()
             mock_create_client.return_value = mock_client
@@ -169,9 +175,10 @@ class TestFactoryFunctions:
             with patch("email_labeler.factory.OPENAI_MODEL", "gpt-3.5-turbo"), patch(
                 "email_labeler.factory.LLM_SERVICE", "OpenAI"
             ):
-                service = create_llm_service()
+                service = create_llm_service(categories=test_categories)
 
                 assert isinstance(service, LLMService)
+                assert service.categories == test_categories
                 mock_create_client.assert_called_once()
 
     def test_create_email_auto_labeler_with_dependencies(self):
@@ -180,8 +187,10 @@ class TestFactoryFunctions:
         mock_llm_service = MagicMock()
         mock_metrics = MagicMock()
         mock_database = MagicMock()
+        test_categories = ["Work", "Personal", "Other"]
 
         labeler = create_email_auto_labeler(
+            categories=test_categories,
             database=mock_database,
             email_processor=mock_processor,
             llm_service=mock_llm_service,
@@ -189,6 +198,7 @@ class TestFactoryFunctions:
         )
 
         assert isinstance(labeler, EmailAutoLabeler)
+        assert labeler.categories == test_categories
         assert labeler.database == mock_database
         assert labeler.email_processor == mock_processor
         assert labeler.llm_service == mock_llm_service
@@ -197,6 +207,8 @@ class TestFactoryFunctions:
     def test_create_email_auto_labeler_without_dependencies(self):
         """Test creating EmailAutoLabeler without dependencies."""
         from email_labeler.config import DATABASE_FILE, LLM_SERVICE
+
+        test_categories = ["Work", "Personal", "Other"]
 
         with patch("email_labeler.factory.create_email_database") as mock_create_db, patch(
             "email_labeler.factory.create_email_processor"
@@ -211,12 +223,13 @@ class TestFactoryFunctions:
             mock_create_processor.return_value = mock_processor
             mock_create_llm.return_value = mock_llm_service
 
-            labeler = create_email_auto_labeler()
+            labeler = create_email_auto_labeler(categories=test_categories)
 
             assert isinstance(labeler, EmailAutoLabeler)
+            assert labeler.categories == test_categories
             mock_create_db.assert_called_once_with(database_file=DATABASE_FILE)
             mock_create_processor.assert_called_once_with(port=8080)
-            mock_create_llm.assert_called_once_with(service=LLM_SERVICE)
+            mock_create_llm.assert_called_once_with(categories=test_categories, service=LLM_SERVICE)
 
     def test_create_test_dependencies(self):
         """Test creating test dependencies."""
@@ -381,15 +394,19 @@ class TestFactoryFunctions:
         mock_conn = MagicMock(spec=sqlite3.Connection)
         mock_gmail = MagicMock()
         mock_llm = MagicMock()
+        test_categories = ["Work", "Personal", "Other"]
 
         # Create components with mocks
         database = create_email_database(conn=mock_conn)
         processor = create_email_processor(gmail_client=mock_gmail)
 
-        llm_service = create_llm_service(llm_client=mock_llm)
+        llm_service = create_llm_service(categories=test_categories, llm_client=mock_llm)
 
         labeler = create_email_auto_labeler(
-            database=database, email_processor=processor, llm_service=llm_service
+            categories=test_categories,
+            database=database,
+            email_processor=processor,
+            llm_service=llm_service,
         )
 
         # Verify mock integration

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -6,6 +6,9 @@ import pytest
 
 from email_labeler.labeler import EmailAutoLabeler
 
+# Test categories for all tests
+TEST_CATEGORIES = ["Marketing", "Work", "Personal", "Bills", "Newsletters", "Other"]
+
 
 class TestEmailAutoLabeler:
     """Test cases for EmailAutoLabeler class."""
@@ -13,11 +16,13 @@ class TestEmailAutoLabeler:
     def test_init(self, mock_email_processor, llm_service, mock_metrics_tracker):
         """Test EmailAutoLabeler initialization."""
         labeler = EmailAutoLabeler(
+            categories=TEST_CATEGORIES,
             email_processor=mock_email_processor,
             llm_service=llm_service,
             metrics_tracker=mock_metrics_tracker,
         )
 
+        assert labeler.categories == TEST_CATEGORIES
         assert labeler.email_processor == mock_email_processor
         assert labeler.llm_service == llm_service
         assert labeler.metrics == mock_metrics_tracker
@@ -100,6 +105,7 @@ class TestEmailAutoLabeler:
         """Test processing in test mode (no actual label application)."""
         # Create labeler in test mode
         email_auto_labeler = EmailAutoLabeler(
+            categories=TEST_CATEGORIES,
             email_processor=mock_email_processor,
             llm_service=llm_service,
             metrics_tracker=mock_metrics_tracker,
@@ -213,6 +219,7 @@ class TestEmailAutoLabeler:
         """Test running in preview mode."""
         # Create labeler in preview mode
         email_auto_labeler = EmailAutoLabeler(
+            categories=TEST_CATEGORIES,
             email_processor=mock_email_processor,
             llm_service=llm_service,
             metrics_tracker=mock_metrics_tracker,
@@ -249,6 +256,7 @@ class TestEmailAutoLabeler:
     def test_metrics_in_test_mode(self, mock_email_processor, llm_service, mock_metrics_tracker):
         """Test that metrics are saved in test mode."""
         email_auto_labeler = EmailAutoLabeler(
+            categories=TEST_CATEGORIES,
             email_processor=mock_email_processor,
             llm_service=llm_service,
             metrics_tracker=mock_metrics_tracker,
@@ -308,6 +316,7 @@ class TestEmailAutoLabeler:
     def test_metrics_tracking(self, mock_email_processor, llm_service, mock_metrics_tracker):
         """Test that metrics are properly tracked in test mode."""
         email_auto_labeler = EmailAutoLabeler(
+            categories=TEST_CATEGORIES,
             email_processor=mock_email_processor,
             llm_service=llm_service,
             metrics_tracker=mock_metrics_tracker,
@@ -368,6 +377,7 @@ class TestEmailAutoLabeler:
         """Test dry run mode functionality (same as preview mode in current implementation)."""
         # Create labeler in preview mode (acts like dry run)
         email_auto_labeler = EmailAutoLabeler(
+            categories=TEST_CATEGORIES,
             email_processor=mock_email_processor,
             llm_service=llm_service,
             metrics_tracker=mock_metrics_tracker,

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -7,6 +7,9 @@ import pytest
 
 from email_labeler.llm_service import LLMService
 
+# Test categories for all tests
+TEST_CATEGORIES = ["Marketing", "Work", "Personal", "Bills", "Newsletters", "Other"]
+
 
 class TestLLMService:
     """Test cases for LLMService class."""
@@ -14,10 +17,11 @@ class TestLLMService:
     def test_init_with_client(self, mock_openai_client):
         """Test initialization with provided client."""
         model = "gpt-4"
-        service = LLMService(llm_client=mock_openai_client, model=model)
+        service = LLMService(categories=TEST_CATEGORIES, llm_client=mock_openai_client, model=model)
 
         assert service.llm_client == mock_openai_client
         assert service.model == model
+        assert service.categories == TEST_CATEGORIES
 
     def test_init_without_client_openai(self):
         """Test initialization without client for OpenAI."""
@@ -26,7 +30,7 @@ class TestLLMService:
         ), patch("email_labeler.llm_service.OPENAI_MODEL", "gpt-3.5-turbo"), patch(
             "email_labeler.llm_service.OpenAI"
         ) as mock_openai:
-            service = LLMService()
+            service = LLMService(categories=TEST_CATEGORIES)
 
             mock_openai.assert_called_once_with(api_key="test-key")
             assert service.model == "gpt-3.5-turbo"
@@ -38,7 +42,7 @@ class TestLLMService:
         ), patch("email_labeler.llm_service.OLLAMA_MODEL", "llama2"), patch(
             "email_labeler.llm_service.OpenAI"
         ) as mock_openai:
-            service = LLMService()
+            service = LLMService(categories=TEST_CATEGORIES)
 
             mock_openai.assert_called_once_with(
                 base_url="http://localhost:11434/v1", api_key="ollama"
@@ -104,7 +108,9 @@ class TestLLMService:
         ].message.content = json.dumps(incomplete_response)
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(email_content)
 
@@ -117,7 +123,9 @@ class TestLLMService:
         mock_openai_client.chat.completions.create.side_effect = Exception("API Error")
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(email_content)
 
@@ -134,7 +142,9 @@ class TestLLMService:
         ].message.content = json.dumps(response)
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(email_content)
 
@@ -146,7 +156,7 @@ class TestLLMService:
         with patch("email_labeler.llm_service.LLM_SERVICE", "OpenAI"), patch(
             "email_labeler.llm_service.OPENAI_API_KEY", "test-key"
         ), patch("email_labeler.llm_service.OpenAI") as mock_openai:
-            service = LLMService()
+            service = LLMService(categories=TEST_CATEGORIES)
             service._get_llm_client()
 
             mock_openai.assert_called_with(api_key="test-key")
@@ -156,7 +166,7 @@ class TestLLMService:
         with patch("email_labeler.llm_service.LLM_SERVICE", "Ollama"), patch(
             "email_labeler.llm_service.OLLAMA_BASE_URL", "http://localhost:11434/v1"
         ), patch("email_labeler.llm_service.OpenAI") as mock_openai:
-            service = LLMService()
+            service = LLMService(categories=TEST_CATEGORIES)
             service._get_llm_client()
 
             mock_openai.assert_called_with(base_url="http://localhost:11434/v1", api_key="ollama")
@@ -178,7 +188,9 @@ class TestLLMService:
         ].message.content = json.dumps(response)
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(content)
 
@@ -198,7 +210,9 @@ class TestLLMService:
             "email_labeler.llm_service.GPT_OSS_REASONING", "medium"
         ):
             # Create LLMService with mocked client - use a gpt-oss model to trigger reasoning
-            llm_service = LLMService(llm_client=mock_openai_client, model="gpt-oss-instruct")
+            llm_service = LLMService(
+                categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-oss-instruct"
+            )
 
             llm_service.categorize_email(email_content)
 
@@ -218,7 +232,9 @@ class TestLLMService:
         ].message.content = json.dumps(response)
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(empty_content)
 
@@ -228,7 +244,9 @@ class TestLLMService:
     def test_log_interaction(self, mock_openai_client):
         """Test logging of LLM interactions."""
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         with patch("builtins.open", create=True) as mock_open, patch(
             "email_labeler.llm_service.LLM_LOG_FILE", "/tmp/test.log"
@@ -244,7 +262,7 @@ class TestLLMService:
 
         for model in models:
             mock_client = MagicMock()
-            service = LLMService(llm_client=mock_client, model=model)
+            service = LLMService(categories=TEST_CATEGORIES, llm_client=mock_client, model=model)
             assert service.model == model
 
     def test_timeout_handling(self, mock_openai_client):
@@ -255,7 +273,9 @@ class TestLLMService:
         mock_openai_client.chat.completions.create.side_effect = APITimeoutError("Request Timeout")
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(email_content)
 
@@ -272,7 +292,9 @@ class TestLLMService:
         )
 
         # Create LLMService with mocked client
-        llm_service = LLMService(llm_client=mock_openai_client, model="gpt-3.5-turbo")
+        llm_service = LLMService(
+            categories=TEST_CATEGORIES, llm_client=mock_openai_client, model="gpt-3.5-turbo"
+        )
 
         category, explanation = llm_service.categorize_email(email_content)
 
@@ -285,6 +307,6 @@ class TestLLMService:
         with patch("email_labeler.llm_service.LLM_SERVICE", "UnsupportedService"), patch(
             "email_labeler.llm_service.OPENAI_API_KEY", "test-key"
         ), patch("email_labeler.llm_service.OpenAI") as mock_openai:
-            LLMService()
+            LLMService(categories=TEST_CATEGORIES)
             # Should fall through to OpenAI case since it's not "Ollama"
             mock_openai.assert_called_with(api_key="test-key")


### PR DESCRIPTION
Email categories were hardcoded in `config.py` as
`CATEGORY_LABELS`. Even though categories could be configured in YAML via
`pipeline.transform.categories`, the LLM service
ignored this configuration and always used the
hardcoded list.